### PR TITLE
Use official API endpoint that doesn't break

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const querystring = require('querystring');
 const crypto = require('crypto')
 const fetch = require('node-fetch')
 
-const API_URL = 'https://3commas.io'
+const API_URL = 'https://api.3commas.io'
 
 class threeCommasAPI {
   constructor(opts = {}) {


### PR DESCRIPTION
The 'https://3commas.io'  endpoint is currently breaking due to CloudFlare getting in the way. The 'https://api.3commas.io' should be used instead. See https://t.me/xcommas_api/1789